### PR TITLE
NH-43641: update execute_and_clear function

### DIFF
--- a/lib/solarwinds_apm/support/swomarginalia/swomarginalia.rb
+++ b/lib/solarwinds_apm/support/swomarginalia/swomarginalia.rb
@@ -11,8 +11,10 @@ module SolarWindsAPM
         super(annotate_sql(sql), *args)
       end
 
-      def execute_and_clear(sql, *args, &block)
-        super(annotate_sql(sql), *args, &block)
+      # only for postgresql adapter
+      def execute_and_clear(sql, *args)
+        name_, binds, prepare = args
+        super(annotate_sql(sql), name_, binds, prepare: prepare.nil?? nil : prepare[:prepare])
       end
 
       def exec_query(sql, *args, **options)

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -5,7 +5,6 @@ require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/reporters'
 require 'minitest'
-require 'minitest/unit'
 require 'minitest/focus'
 require 'minitest/debugger' if ENV['DEBUG']
 require 'minitest/hooks/default'  # adds after(:all)


### PR DESCRIPTION
Based on activerecord postgresql adapter 5 -> 7, the execute_and_clear only take static number of args.
See [rails code](https://github.com/rails/rails/blob/v7.0.7/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L740)