### PR TITLE
NH-54297: update lumberjack for tracecontext in logs

### DIFF
--- a/lib/solarwinds_apm/support/lumberjack_formatter.rb
+++ b/lib/solarwinds_apm/support/lumberjack_formatter.rb
@@ -1,6 +1,21 @@
-# Copyright (c) 2019 SolarWinds, LLC.
+# Copyright (c) 2023 SolarWinds, LLC.
 # All rights reserved.
 
 require_relative 'logger_formatter'
 
-Lumberjack::Formatter.prepend(SolarWindsAPM::Logger::Formatter) if SolarWindsAPM.loaded && defined?(Lumberjack::Formatter)
+module SolarWindsAPM
+  module Lumberjack
+    module LogEntry
+      include SolarWindsAPM::Logger::Formatter # provides #insert_trace_id
+
+      def initialize(time, severity, message, progname, pid, tags)
+        super if SolarWindsAPM::Config[:log_traceId] == :never
+
+        message = insert_trace_id(message)
+        super
+      end
+    end
+  end
+end
+
+Lumberjack::LogEntry.prepend(SolarWindsAPM::Lumberjack::LogEntry) if SolarWindsAPM.loaded && defined?(Lumberjack::LogEntry)

--- a/test/unit/trace_context_log_test.rb
+++ b/test/unit/trace_context_log_test.rb
@@ -57,7 +57,6 @@ describe 'Trace Context in Log Test' do
 
   it 'test_logging_traceId_with_debug_sampled' do
     SolarWindsAPM::Config[:log_traceId] = :sampled
-    # log_output = StringIO.new
     logger = Logging.logger(@log_output)
     logger.level = :debug
     logger.debug "Sample debug message"
@@ -67,13 +66,54 @@ describe 'Trace Context in Log Test' do
 
   # lumberjack can't work in prepend Formatter anymore.
   # use logger.tag(context: lambda {SolarWindsAPM::API.current_trace_info.for_log})
-  it 'test_propagators_with_default' do
+  it 'test_lumberjack_with_tag_debug_sampled' do
     SolarWindsAPM::Config[:log_traceId] = :always
     logger = Lumberjack::Logger.new(@log_output, :level => :debug)
     logger.tag(tracecontext: -> {SolarWindsAPM::API.current_trace_info.for_log})
     logger.debug("Sample debug message")
     @log_output.rewind
     assert_includes @log_output.read, 'trace_id=00000000000000000000000000000000 span_id=0000000000000000 trace_flags=00 resource.service.name='
+  end
+
+  it 'test_lumberjack_with_debug_sampled' do
+    SolarWindsAPM::Config[:log_traceId] = :always
+    logger = Lumberjack::Logger.new(@log_output, :level => :debug)
+    logger.debug("Sample debug message")
+    @log_output.rewind
+    assert_includes @log_output.read, 'trace_id=00000000000000000000000000000000 span_id=0000000000000000 trace_flags=00 resource.service.name='
+  end
+
+  it 'test_lumberjack_with_debug_sampled_valid_span' do
+    SolarWindsAPM::Config[:log_traceId] = :always
+    logger = Lumberjack::Logger.new(@log_output, :level => :debug)
+
+    OpenTelemetry::SDK.configure do |c|
+      c.service_name = 'my_service'
+      c.add_span_processor(::OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(::OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new))
+    end
+
+    OpenTelemetry.tracer_provider.tracer('my_service').in_span('sample_span') do |span|
+      span.context.trace_flags.instance_variable_set(:@flags, 1)
+      logger.debug "Sample debug message"
+    end
+
+    @log_output.rewind
+    log_output = @log_output.read
+
+    trace_id = log_output.match(/trace_id=([\da-fA-F]+)/)
+
+    assert_equal(trace_id&.size, 2)
+    assert_equal(trace_id[1]&.size, 32)
+    
+    span_id  = log_output.match(/span_id=([\da-fA-F]+)/)
+    assert_equal(span_id&.size, 2)
+    assert_equal(span_id[1]&.size, 16)
+
+    trace_flags  = log_output.match(/trace_flags=([\da-fA-F]+)/)
+    assert_equal(trace_flags&.size, 2)
+    assert_equal(trace_flags[1]&.size, 2)
+
+    refute_includes(log_output, "trace_id=00000000000000000000000000000000 span_id=0000000000000000 trace_flags=00")
   end
 
   it 'test_log_traceId_with_debug_always_valid_span' do


### PR DESCRIPTION
Lumberjack is initialized with `logger = Lumberjack::Logger.new()`. When using `Lumberjack::Logger`, a new` LogEntry` class is created through the `add_entry` method, and our focus is on prepending this `LogEntry`. 

When invoking methods like `logger.info()` or `logger.debug()`, they utilize `call_add_entry`, which subsequently calls `add_entry`. Within this method, the initial message, which can be of types like Proc, string, or tag, gets processed by `formatter.format(message)`. This function leverages specific formatters from `lib/lumberjack/formatter/*.rb` to finalize the message string.