### PR TITLE
NH-54725: make prepend on activerecord 6 and 7 compatible

### DIFF
--- a/lib/solarwinds_apm/support.rb
+++ b/lib/solarwinds_apm/support.rb
@@ -31,10 +31,8 @@ if SolarWindsAPM::Config[:tag_sql]
       SolarWindsAPM.logger.info {"For more information, please check https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html"}
       require_relative './support/swomarginalia/comment'
     end
-  elsif defined?(::ActiveRecord) && ::ActiveRecord.version.to_s < '7'
+  elsif defined?(::ActiveRecord)
     require_relative './support/swomarginalia/load_swomarginalia'
     SolarWindsAPM::SWOMarginalia::LoadSWOMarginalia.insert
-  else
-    SolarWindsAPM.logger.info {"tag_sql currently is not supported in non-rails app that use active_record > 7"}
   end
 end

--- a/lib/solarwinds_apm/support/swomarginalia/swomarginalia.rb
+++ b/lib/solarwinds_apm/support/swomarginalia/swomarginalia.rb
@@ -7,14 +7,13 @@ module SolarWindsAPM
     # This ActiveRecordInstrumentation should only work for activerecord < 7.0 since after rails 7
     # this module won't be prepend to activerecord
     module ActiveRecordInstrumentation
-      def execute(sql, *args)
-        super(annotate_sql(sql), *args)
+      def execute(sql, *args, **options)
+        super(annotate_sql(sql), *args, **options)
       end
 
       # only for postgresql adapter
-      def execute_and_clear(sql, *args)
-        name_, binds, prepare = args
-        super(annotate_sql(sql), name_, binds, prepare: prepare.nil?? nil : prepare[:prepare])
+      def execute_and_clear(sql, *args, **options)
+        super(annotate_sql(sql), *args, **options)
       end
 
       def exec_query(sql, *args, **options)


### PR DESCRIPTION
## Description
Use the ruby convention to supply `*args` and `**options` for any additional arguments which include hash arguments)

## Test
All tests have been done with testbed
activerecord < 7 with mysql2
activerecord < 7 with postgres
activerecord > 7 with mysql2
activerecord > 7 with postgres