### PR TITLE
set_transaction_name conform to our spec and test updates

### DIFF
--- a/lib/solarwinds_apm.rb
+++ b/lib/solarwinds_apm.rb
@@ -2,7 +2,7 @@
 # All rights reserved.
 
 begin
-  if ENV.has_key?('SW_APM_ENABLED') && (ENV['SW_APM_ENABLED'] == 'false' || ENV['SW_APM_ENABLED'] == false)
+  if ENV.fetch('SW_APM_ENABLED', 'true') == 'false'
     SolarWindsAPM.logger.warn 'SW_APM_ENABLED environment variable detected and was set to false; SolarWindsAPM disabled'
     return
   end
@@ -53,7 +53,7 @@ begin
     require 'solarwinds_apm/otel_config'
     if ENV['SW_APM_AUTO_CONFIGURE'] == 'false'
       SolarWindsAPM.logger.warn "SolarWindsAPM warning: Ruby library is not initilaized.
-                                  You may need to initialize Ruby library in application like the following: 
+                                  You may need to initialize Ruby library in application like the following:
                                   SolarWindsAPM::OTelConfig.initialize_with_config do |config|
                                     ...
                                   end"

--- a/test/api/set_transaction_name_test.rb
+++ b/test/api/set_transaction_name_test.rb
@@ -13,15 +13,12 @@ describe 'SolarWinds Set Transaction Name Test' do
     @span = create_span
     @dummy_span = create_span
     @dummy_span.context.instance_variable_set(:@span_id, 'fake_span_id') # with fake span_id, should still find the right root span
-
-    txn_manager = SolarWindsAPM::TxnNameManager.new
-    exporter    = SolarWindsAPM::OpenTelemetry::SolarWindsExporter.new(txn_manager: txn_manager)
-
     @solarwinds_processor = SolarWindsAPM::OTelConfig.resolve_solarwinds_processor
   end
 
   after do
     @span.context.trace_flags.instance_variable_set(:@flags, 0)
+    ENV.delete('SW_APM_ENABLED')
   end
 
   it 'set_transaction_name_when_not_sampled' do
@@ -59,6 +56,23 @@ describe 'SolarWinds Set Transaction Name Test' do
       _(result).must_equal false
     end
     assert_nil(@solarwinds_processor.txn_manager.get("77cb6ccc522d3106114dd6ecbb70036a-31e175128efc4018"))
+  end
+
+  it 'set_transaction_name_when_library_noop' do
+    SolarWindsAPM::Context.stub(:toString, '99-00000000000000000000000000000000-0000000000000000-00') do
+      @solarwinds_processor.on_start(@span, ::OpenTelemetry::Context.current)
+      OpenTelemetry::Trace.stub(:current_span, @dummy_span) do
+        result = SolarWindsAPM::API.set_transaction_name('abcdf')
+        _(result).must_equal true
+      end
+      assert_nil(@solarwinds_processor.txn_manager.get("77cb6ccc522d3106114dd6ecbb70036a-31e175128efc4018"))
+    end
+  end
+
+  it 'set_transaction_name_when_library_disabled' do
+    ENV['SW_APM_ENABLED'] = 'false'
+    result = SolarWindsAPM::API.set_transaction_name('abcdf')
+    _(result).must_equal true
   end
 
 end


### PR DESCRIPTION
This PR is an extension of #81, details in https://swicloud.atlassian.net/browse/NH-62985. 

There are still `in_span` test failures but that should be addressed either in the original #81 or as a separate PR.  The set_transaction_name tests no longer seem to suffer from the sporadic error.