### PR TITLE
NH-64310: remove the logic that set obfuscate for db from sw side

### DIFF
--- a/lib/solarwinds_apm/otel_config.rb
+++ b/lib/solarwinds_apm/otel_config.rb
@@ -65,20 +65,6 @@ module SolarWindsAPM
       end
     end
 
-    def self.obfuscate_helper(instrumentation)
-      if @@config_map[instrumentation] # user provided the option
-        @@config_map[instrumentation][:db_statement] = :obfuscate unless @@config_map[instrumentation][:db_statement] # user provided the db_statement, ignore our default setting 
-      else
-        @@config_map[instrumentation] = {db_statement: :obfuscate}
-      end
-    end
-
-    def self.obfuscate_query
-      obfuscate_helper("OpenTelemetry::Instrumentation::Dalli")
-      obfuscate_helper("OpenTelemetry::Instrumentation::Mysql2")
-      obfuscate_helper("OpenTelemetry::Instrumentation::PG")
-    end
-
     def self.[](key)
       @@config[key.to_sym]
     end
@@ -131,8 +117,6 @@ module SolarWindsAPM
       resolve_solarwinds_propagator
       resolve_solarwinds_processor
       resolve_response_propagator
-
-      obfuscate_query
 
       print_config if SolarWindsAPM.logger.level.zero?
 


### PR DESCRIPTION
## Description

As https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/682 merged, no need this logic so remove them. Although, for RUBY 2.7, still need to manual set the obfuscate for instrumentation if needed.

e.g.
```
SolarWindsAPM::OTelConfig.initialize_with_config do |config|
  config["OpenTelemetry::Instrumentation::Dalli"] = {db_statement: :obfuscate}
  config["OpenTelemetry::Instrumentation::Mysql2"] = {db_statement: :obfuscate}
  config["OpenTelemetry::Instrumentation::PG"] = {db_statement: :obfuscate}
end
```