### PR TITLE
NH-70338: update workflow for amzlinux 2 on checkout version

### DIFF
--- a/.github/workflows/verify_install.yml
+++ b/.github/workflows/verify_install.yml
@@ -113,7 +113,15 @@ jobs:
     steps:
       - if: ${{ startsWith(matrix.image, 'amazonlinux') }}
         run: yum install -y tar gzip
-      - uses: actions/checkout@v4
+
+      - name: Checkout ${{ github.ref }}
+        if: ${{ matrix.hostname == 'rb3.1.0-amazlinux2' }}
+        uses: actions/checkout@v3
+
+      - name: Checkout ${{ github.ref }}
+        if: ${{ matrix.hostname != 'rb3.1.0-amazlinux2' }}
+        uses: actions/checkout@v4
+
       - name: Verify install
         working-directory: .github/workflows/scripts
         run: ./verify_install.sh


### PR DESCRIPTION
### Description

action/checkout@4 is not suitable for amazon linux 2 due to node version on glibc; so condition it out

### Test (if applicable)
