### PR TITLE
NH-43527: add support of activerecord 7.1 for non-rails app

### DIFF
--- a/lib/solarwinds_apm/support.rb
+++ b/lib/solarwinds_apm/support.rb
@@ -22,14 +22,11 @@ if SolarWindsAPM::Config[:tag_sql]
     if ::Rails.version < '7'
       require_relative './support/swomarginalia/railtie'
     elsif ::Rails.version >= '7'
-      # User has to define in their config/environments:
-      # config.active_record.query_log_tags = [ 
-      #   { 
-      #     tracecontext: -> { 
-      #       SolarWindsAPM::SWOMarginalia::Comment.traceparent 
-      #     } 
-      #   }
-      # ]
+      # User has to configure application.rb with
+      # config.active_record.query_log_tags_enabled = true
+      #
+      # User has to configure environments/*.rb with
+      # config.active_record.query_log_tags = [{ traceparent: -> { SolarWindsAPM::SWOMarginalia::Comment.traceparent } }]
       SolarWindsAPM.logger.info {"In Rails 7, tag tracecontext on a query by including SolarWindsAPM::SWOMarginalia::Comment.traceparent as function in config.active_record.query_log_tags."}
       SolarWindsAPM.logger.info {"For more information, please check https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html"}
       require_relative './support/swomarginalia/comment'

--- a/lib/solarwinds_apm/support/swomarginalia/README.md
+++ b/lib/solarwinds_apm/support/swomarginalia/README.md
@@ -29,6 +29,10 @@ This folder contains the code that is copied from original [marginalia](https://
 ### load_swomarginalia.rb
 1. (new file) prepend the ActiveRecordInstrumentation to activerecord adapter
 
+### annotation.rb
+1. (new file) utilize comment file append the generated traceparent data into sql
+2. If sql already contains the same comments, then it won't inject again
+
 ## Example
 
 ### Sample output of rails application

--- a/lib/solarwinds_apm/support/swomarginalia/annotation.rb
+++ b/lib/solarwinds_apm/support/swomarginalia/annotation.rb
@@ -1,0 +1,36 @@
+require_relative './comment'
+
+module SolarWindsAPM
+  module SWOMarginalia
+    module Annotation
+      def annotate_sql(sql)
+        SWOMarginalia::Comment.update_adapter!(self)            # switch to current sql adapter
+        comment = SWOMarginalia::Comment.construct_comment      # comment will include traceparent
+        if comment.present? && !sql.include?(comment)
+          sql = if SWOMarginalia::Comment.prepend_comment
+                  "/*#{comment}*/ #{sql}"
+                else
+                  "#{sql} /*#{comment}*/"
+                end
+        end
+
+        inline_comment = SWOMarginalia::Comment.construct_inline_comment # this is for customized_swo_inline_annotations (user-defined value)
+        if inline_comment.present? && !sql.include?(inline_comment)
+          sql = if SWOMarginalia::Comment.prepend_comment
+                  "/*#{inline_comment}*/ #{sql}"
+                else
+                  "#{sql} /*#{inline_comment}*/"
+                end
+        end
+
+        sql
+      end
+
+      # We don't want to trace framework caches.
+      # Only instrument SQL that directly hits the database.
+      def ignore_payload?(name)
+        %w[SCHEMA EXPLAIN CACHE].include?(name.to_s)
+      end
+    end
+  end
+end

--- a/lib/solarwinds_apm/support/swomarginalia/load_swomarginalia.rb
+++ b/lib/solarwinds_apm/support/swomarginalia/load_swomarginalia.rb
@@ -41,14 +41,12 @@ module SolarWindsAPM
       end
 
       def self.insert_into_active_record
-        ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend(SWOMarginalia::ActiveRecordInstrumentation) if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
-        ActiveRecord::ConnectionAdapters::MysqlAdapter.prepend(SWOMarginalia::ActiveRecordInstrumentation) if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
+        # only rails < 5 has MysqlAdapter (https://github.com/rails/rails/tree/v4.2.11.3/activerecord/lib/active_record/connection_adapters)
+        ActiveRecord::ConnectionAdapters::MysqlAdapter.prepend(SWOMarginalia::ActiveRecordInstrumentation)      if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
+        ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend(SWOMarginalia::ActiveRecordInstrumentation)     if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
         ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(SWOMarginalia::ActiveRecordInstrumentation) if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-        return unless defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
-
-        ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend(SWOMarginalia::ActiveRecordInstrumentation) if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
+        ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend(SWOMarginalia::ActiveRecordInstrumentation)    if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
       end
     end
   end
 end
-

--- a/lib/solarwinds_apm/support/swomarginalia/load_swomarginalia.rb
+++ b/lib/solarwinds_apm/support/swomarginalia/load_swomarginalia.rb
@@ -46,6 +46,7 @@ module SolarWindsAPM
         ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend(SWOMarginalia::ActiveRecordInstrumentation)     if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
         ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(SWOMarginalia::ActiveRecordInstrumentation) if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
         ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend(SWOMarginalia::ActiveRecordInstrumentation)    if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
+        ActiveRecord::ConnectionAdapters::TrilogyAdapter.prepend(SWOMarginalia::ActiveRecordInstrumentation)    if defined? ActiveRecord::ConnectionAdapters::TrilogyAdapter
       end
     end
   end


### PR DESCRIPTION
### Description

This patch is for non-rails app (e.g. sinatra) that use activerecord >= 7.1.0
From 7.1.0, query() changed calling from exec_query() to internal_exec_query()
Postgresql is not affected by this because in psql, internal_exec_query calls execute_and_clear

### Test (if applicable)

Sinatra + ActiveRecord 7.1.3 on MySQL [Trace Info](https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/188787FE77AF0C3E0CA3E20CDD9948D0/FBCA35E202FEF348/details/query?duration=3600&perspective=requests&serviceId=e-1681745371022536704&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending&sort_by_queries=totalTime&sort_order_queries=descending)
