### PR TITLE
NH-86570: add swomarginalia support to rails 7~7.1 regard to format

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,3 +47,4 @@ Naming/VariableNumber:
 Metrics/BlockNesting:
   Exclude:
     - 'lib/solarwinds_apm.rb'
+    - 'lib/solarwinds_apm/support.rb'

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -156,6 +156,48 @@ SolarWindsAPM::Config[:transaction_settings] = [
 ]
 ```
 
+### Tag Trace Context with Query
+
+You can set `SW_APM_TAG_SQL=true` or set `:tag_sql` to true in the configuration file to enable appending current trace information into the query. For example:
+```
+# query without tag sql
+SELECT * FROM SAMPLE_TABLE WHERE user_id = 1;
+
+# query with tag sql
+SELECT * FROM SAMPLE_TABLE WHERE user_id = 1; /* traceparent=7435a9fe510ae4533414d425dadf4e18-49e60702469db05f-01 */
+```
+
+For Rails < 7 and non-Rails applications, we use [Marginalia](https://github.com/basecamp/marginalia) to inject comments in ActiveRecord.
+
+For Rails >= 7, Rails integrates Marginalia into its framework (see [documentation](https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html)). You can set up the tag SQL through Rails configuration. See the example:
+```ruby
+class Application < Rails::Application
+  config.active_record.query_log_tags_enabled = true
+  config.active_record.query_log_tags = [
+    {
+      traceparent: -> {
+        SolarWindsAPM::SWOMarginalia::Comment.traceparent
+      }
+    }
+  ]
+end
+```
+
+For Rails >= 7.1, you can change the comment format from the default to SQLCommenter (SolarWindsAPM enforces the SQLCommenter format):
+```ruby
+class Application < Rails::Application
+  config.active_record.query_log_tags_enabled = true
+  config.active_record.query_log_tags = [
+    {
+      traceparent: -> {
+        SolarWindsAPM::SWOMarginalia::Comment.traceparent
+      }
+    }
+  ]
+  config.active_record.query_log_tags_format = :sqlcommenter
+end
+```
+
 ## Reference
 
 Environment Variable | Config File Key | Description | Default

--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,7 @@ end
 
 desc 'Start ubuntu docker container for testing and debugging.'
 task docker_dev: [:docker_down] do
-  cmd = "docker-compose run --service-ports \
+  cmd = "docker compose run --service-ports \
   --name ruby_sw_apm_ubuntu_development ruby_sw_apm_ubuntu_development"
   Dir.chdir('test') do
     sh cmd do |ok, res|
@@ -81,7 +81,7 @@ end
 desc 'Stop all containers that were started for testing and debugging'
 task :docker_down do
   Dir.chdir('test') do
-    sh 'docker-compose down -v --remove-orphans'
+    sh 'docker compose down -v --remove-orphans'
   end
 end
 

--- a/lib/solarwinds_apm/support.rb
+++ b/lib/solarwinds_apm/support.rb
@@ -19,25 +19,18 @@ require_relative 'support/utils'
 require_relative 'support/x_trace_options'
 require_relative 'support/support_report'
 
+# rubocop:disable Metrics/BlockNesting
 if SolarWindsAPM::Config[:tag_sql]
   if defined?(Rails)
-
-    if Rails.version >= '7'
-      SolarWindsAPM.logger.info do
-        'In Rails 7, tag tracecontext on a query by including SolarWindsAPM::SWOMarginalia::Comment.traceparent as a function in config.active_record.query_log_tags. ' \
-          'In Rails >= 7.1, change the default formatter to sqlcommenter via config.active_record.query_log_tags_format = :sqlcommenter for the correct format. ' \
-          'For more info, visit https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html'
-      end
-      require_relative 'support/swomarginalia/comment'
-    end
-
     if Rails.version < '7'
       require_relative 'support/swomarginalia/railtie'
-    elsif Rails.version >= '7' && Rails.version < '7.1'
-      require_relative 'support/swomarginalia/formatter'
+    else
+      require_relative 'support/swomarginalia/comment'
+      require_relative 'support/swomarginalia/formatter' if Rails.version <= '7.1'
     end
   elsif defined?(ActiveRecord)
     require_relative 'support/swomarginalia/load_swomarginalia'
     SolarWindsAPM::SWOMarginalia::LoadSWOMarginalia.insert
   end
 end
+# rubocop:enable Metrics/BlockNesting

--- a/lib/solarwinds_apm/support.rb
+++ b/lib/solarwinds_apm/support.rb
@@ -19,7 +19,6 @@ require_relative 'support/utils'
 require_relative 'support/x_trace_options'
 require_relative 'support/support_report'
 
-# rubocop:disable Metrics/BlockNesting
 if SolarWindsAPM::Config[:tag_sql]
   if defined?(Rails)
     if Rails.version < '7'
@@ -33,4 +32,3 @@ if SolarWindsAPM::Config[:tag_sql]
     SolarWindsAPM::SWOMarginalia::LoadSWOMarginalia.insert
   end
 end
-# rubocop:enable Metrics/BlockNesting

--- a/lib/solarwinds_apm/support.rb
+++ b/lib/solarwinds_apm/support.rb
@@ -21,22 +21,20 @@ require_relative 'support/support_report'
 
 if SolarWindsAPM::Config[:tag_sql]
   if defined?(Rails)
+
+    if Rails.version >= '7'
+      SolarWindsAPM.logger.info do
+        'In Rails 7, tag tracecontext on a query by including SolarWindsAPM::SWOMarginalia::Comment.traceparent as a function in config.active_record.query_log_tags. ' \
+          'In Rails >= 7.1, change the default formatter to sqlcommenter via config.active_record.query_log_tags_format = :sqlcommenter for the correct format. ' \
+          'For more info, visit https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html'
+      end
+      require_relative 'support/swomarginalia/comment'
+    end
+
     if Rails.version < '7'
       require_relative 'support/swomarginalia/railtie'
-    elsif Rails.version >= '7'
-      # User has to define in their config/environments:
-      # config.active_record.query_log_tags = [
-      #   {
-      #     tracecontext: -> {
-      #       SolarWindsAPM::SWOMarginalia::Comment.traceparent
-      #     }
-      #   }
-      # ]
-      SolarWindsAPM.logger.info do
-        'In Rails 7, tag tracecontext on a query by including SolarWindsAPM::SWOMarginalia::Comment.traceparent as function in config.active_record.query_log_tags.'
-      end
-      SolarWindsAPM.logger.info { 'For more information, please check https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html' }
-      require_relative 'support/swomarginalia/comment'
+    elsif Rails.version >= '7' && Rails.version < '7.1'
+      require_relative 'support/swomarginalia/formatter'
     end
   elsif defined?(ActiveRecord)
     require_relative 'support/swomarginalia/load_swomarginalia'

--- a/lib/solarwinds_apm/support/swomarginalia/formatter.rb
+++ b/lib/solarwinds_apm/support/swomarginalia/formatter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SolarWindsAPM
+  module SWOMarginalia
+    module Formatter
+      def tag_content
+        comment = super
+        comment.tr!(':', '=')
+        comment
+      end
+    end
+  end
+end
+
+# Prepend the Formatter module to the singleton class of ActiveRecord::QueryLogs
+if defined?(ActiveRecord::QueryLogs)
+  class << ActiveRecord::QueryLogs
+    prepend SolarWindsAPM::SWOMarginalia::Formatter
+  end
+end

--- a/solarwinds_apm.gemspec
+++ b/solarwinds_apm.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
 
   # this still gives a warning, would have to be pinned to a minor version
   # but that is not necessary and may restrict other gems
-  s.add_runtime_dependency('json', '~> 2.0')
+  s.add_dependency('json', '~> 2.0')
 
   s.required_ruby_version = '>= 2.7.0'
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
### Description

This fix the issue that when using rails default marginalia from rails v7.0 - 7.1, the format is enforced with `key:value`, while we need `key=value`.

Added the configuration for query tag and example in README

### Test (if applicable)
