### PR TITLE
NH-85973 instrument function handler dependencies

### DIFF
--- a/lambda/otel/layer/otel_wrapper.rb
+++ b/lambda/otel/layer/otel_wrapper.rb
@@ -3,9 +3,11 @@
 require 'opentelemetry-metrics-api'
 require 'opentelemetry-metrics-sdk'
 require 'opentelemetry-exporter-otlp'
+require 'opentelemetry/instrumentation/aws_lambda/handler'
+
+otel_lambda_handler = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
 require 'solarwinds_apm'
 
-def otel_wrapper(event:, context:)
-  otel_wrapper = OpenTelemetry::Instrumentation::AwsLambda::Handler.new
-  otel_wrapper.call_wrapped(event: event, context: context)
+define_method(:otel_wrapper) do |event:, context:|
+  otel_lambda_handler.call_wrapped(event: event, context: context)
 end


### PR DESCRIPTION
### Description

From Jira discussion it seems possible to try loading the original handler file (causing all function dependencies to also be loaded), then load `solarwinds_apm` which will bootstrap instrumentations based on loaded libraries.

This is a POC for how we might use the existing OTel Lambda Handler instrumentation's [resolve_original_handler](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/aws_lambda/lib/opentelemetry/instrumentation/aws_lambda/handler.rb#L25) on initialization to achieve the loading.

### Test (if applicable)

Quick test with this change and a function that requires the `aws-sdk-lambda` gem has this in CW log:
```I, [2024-07-24T23:09:51.172528 #15]  INFO  -- : Instrumentation: OpenTelemetry::Instrumentation::AwsSdk was successfully installed with the following options {:inject_messaging_context=>false, :suppress_internal_instrumentation=>false}```

Unfortunately I'm still not getting the AWS SDK span, maybe due to span context issue that would be fixed by https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1073

