### PR TITLE
refactor debug msg

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -205,3 +205,18 @@ end
 ```
 
 Note that with Rails >= 7.1 the comment format can be specified via the `config.active_record.query_log_tags_format` option. SolarWinds Observability functionality depends on the default `:sqlcommenter` format, it is not recommended to change this value.
+
+#### Change db_statment option to `:include`
+
+> [!IMPORTANT]
+> The `db_statement` option for database-related instrumentation needs to be set to `:include`
+
+In OpenTelemetry Instrumentation, all database-related instrumentation sets the attribute `db.statement` to `:obfuscate` by default (e.g., [mysql2](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/opentelemetry-instrumentation-mysql2/v0.27.2/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb#L23), [pg](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/opentelemetry-instrumentation-pg/v0.28.0/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb#L28), and [trilogy](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/opentelemetry-instrumentation-trilogy/v0.59.3/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/instrumentation.rb#L27)). `Obfuscate` will mask out every sensitive value, including comments; therefore, to overcome this setting, the option `db_statement` needs to be set to `:include`.
+
+To change the default value of the instrumentation option, please refer to the [Environment Variables](#environment-variables) or [Programmatic Configuration](#programmatic-configuration).
+
+For example, to set the `db_statement` option for the mysql2 instrumentation to "include", export the following environment variable:
+
+```console
+export OTEL_RUBY_INSTRUMENTATION_MYSQL2_CONFIG_OPTS='db_statement=include'
+```

--- a/lib/solarwinds_apm.rb
+++ b/lib/solarwinds_apm.rb
@@ -73,7 +73,6 @@ begin
             SolarWindsAPM.logger.warn '  # ... your configuration code'
             SolarWindsAPM.logger.warn 'end'
             SolarWindsAPM.logger.warn 'See: https://github.com/solarwinds/apm-ruby/blob/main/CONFIGURATION.md#in-code-configuration'
-            SolarWindsAPM.logger.warn "\e[1mPlease discard this message if application have already taken this action.\e[0m"
             SolarWindsAPM.logger.warn '=============================================================='
           end
         else

--- a/lib/solarwinds_apm/opentelemetry/otlp_processor.rb
+++ b/lib/solarwinds_apm/opentelemetry/otlp_processor.rb
@@ -22,7 +22,7 @@ module SolarWindsAPM
       # @param [Context] parent_context the
       #  started span.
       def on_start(span, parent_context)
-        SolarWindsAPM.logger.debug { "[#{self.class}/#{__method__}] processor on_start span: #{span.inspect}" }
+        SolarWindsAPM.logger.debug { "[#{self.class}/#{__method__}] processor on_start span: #{span.to_span_data.inspect}" }
 
         return if non_entry_span(parent_context: parent_context)
 

--- a/lib/solarwinds_apm/opentelemetry/solarwinds_processor.rb
+++ b/lib/solarwinds_apm/opentelemetry/solarwinds_processor.rb
@@ -30,7 +30,7 @@ module SolarWindsAPM
       #  started span.
       def on_start(span, parent_context)
         SolarWindsAPM.logger.debug do
-          "[#{self.class}/#{__method__}] processor on_start span: #{span.inspect}, parent_context: #{parent_context.inspect}"
+          "[#{self.class}/#{__method__}] processor on_start span: #{span.to_span_data.inspect}"
         end
 
         return if non_entry_span(parent_context: parent_context)
@@ -47,7 +47,7 @@ module SolarWindsAPM
       #
       # @param [Span] span the {Span} that just ended.
       def on_finish(span)
-        SolarWindsAPM.logger.debug { "[#{self.class}/#{__method__}] processor on_finish span: #{span.inspect}" }
+        SolarWindsAPM.logger.debug { "[#{self.class}/#{__method__}] processor on_finish span: #{span.to_span_data.inspect}" }
 
         return if non_entry_span(span: span)
 

--- a/lib/solarwinds_apm/opentelemetry/solarwinds_propagator.rb
+++ b/lib/solarwinds_apm/opentelemetry/solarwinds_propagator.rb
@@ -54,7 +54,7 @@ module SolarWindsAPM
           SolarWindsAPM.logger.debug { "[#{self.class}/#{__method__}] inject context: #{context.inspect}" }
 
           span_context = ::OpenTelemetry::Trace.current_span(context)&.context
-          SolarWindsAPM.logger.debug { "[#{self.class}/#{__method__}] span_context #{span_context.inspect}" }
+          SolarWindsAPM.logger.debug { "[#{self.class}/#{__method__}] span_context: #{span_context.inspect}" }
           return unless span_context&.valid?
 
           trace_flag = span_context.trace_flags.sampled? ? 1 : 0

--- a/lib/solarwinds_apm/opentelemetry/solarwinds_response_propagator.rb
+++ b/lib/solarwinds_apm/opentelemetry/solarwinds_response_propagator.rb
@@ -35,9 +35,10 @@ module SolarWindsAPM
         def inject(carrier, context: ::OpenTelemetry::Context.current,
                    setter: ::OpenTelemetry::Context::Propagation.text_map_setter)
           span_context = ::OpenTelemetry::Trace.current_span(context).context
-          SolarWindsAPM.logger.debug do
-            "[#{self.class}/#{__method__}] context: #{context.inspect}; span_context: #{span_context.inspect}"
-          end
+
+          SolarWindsAPM.logger.debug { "[#{self.class}/#{__method__}] context current_span: #{context.instance_variable_get(:@entries)&.values&.first.inspect}" }
+          SolarWindsAPM.logger.debug { "[#{self.class}/#{__method__}] span_context: #{span_context.inspect}" }
+
           return unless span_context&.valid?
 
           x_trace                = Utils.traceparent_from_context(span_context)

--- a/lib/solarwinds_apm/otel_config.rb
+++ b/lib/solarwinds_apm/otel_config.rb
@@ -126,6 +126,13 @@ module SolarWindsAPM
 
       # configure sampler afterwards
       ::OpenTelemetry.tracer_provider.sampler = @@config[:sampler]
+
+      if ENV['SW_APM_AUTO_CONFIGURE'] == 'false'
+        SolarWindsAPM.logger.info '==================================================================='
+        SolarWindsAPM.logger.info "\e[1mSolarWindsAPM manual initialization was successful.\e[0m"
+        SolarWindsAPM.logger.info '==================================================================='
+      end
+
       nil
     end
 


### PR DESCRIPTION
### Description

1. Add a warn log to indicate that user's manual initialization success
2. Reduce the duplicate debug msg from context where the same current-span context show up twice.
3. Use span.to_span_data for more clear debug msg.
 
### Test (if applicable)
