### PR TITLE
NH-89406: improve control for building debug version of the extension and added documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ appoptics.com
 test/clib/Makefile
 *.so
 *.o
+*.so.debug
+ext/oboe_metal/extconf_local.rb
 
 # test script
 install_gem.sh

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ test/clib/Makefile
 *.so
 *.o
 ext/oboe_metal/extconf_local.rb
+Makefile
 
 # test script
 install_gem.sh

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
   NewCops: enable
   Exclude:
     - 'sample_start.rb'
+    - 'ext/oboe_metal/extconf_local.rb'
 
 Layout/LineLength:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -151,15 +151,6 @@ task :fetch_oboe_file, [:env] do |_t, args|
 
   fetch_file_from_cloud(files, oboe_dir, ext_src_dir, 'include')
 
-  debug_files = %w[liboboe-1.0-aarch64.so.debug
-                   liboboe-1.0-alpine-aarch64.so.debug
-                   liboboe-1.0-alpine-x86_64.so.debug
-                   liboboe-1.0-lambda-aarch64.so.debug
-                   liboboe-1.0-lambda-x86_64.so.debug
-                   liboboe-1.0-x86_64.so.debug]
-
-  fetch_file_from_cloud(debug_files, oboe_dir, ext_lib_dir, 'debug')
-
   sha_files = ['liboboe-1.0-lambda-x86_64.so.sha256',
                'liboboe-1.0-lambda-aarch64.so.sha256',
                'liboboe-1.0-x86_64.so.sha256',

--- a/Rakefile
+++ b/Rakefile
@@ -33,6 +33,7 @@ Rake::TestTask.new do |t|
                    FileList['test/solarwinds_apm/*_test.rb'] +
                    FileList['test/opentelemetry/*_test.rb'] +
                    FileList['test/noop/*_test.rb'] +
+                   FileList['test/ext/*_test.rb'] +
                    FileList['test/support/*_test.rb'] -
                    FileList['test/support/swomarginalia/*_test.rb']
   end

--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,8 @@ Rake::TestTask.new do |t|
   end
 end
 
+################ Docker Task ################
+
 desc "Run an official docker ruby image with the specified tag. The test suite is launched if
 runtests is set to true, else a shell session is started for interactive test runs. The platform
 argument can be used to override the image architecture if multi-platform is supported.
@@ -71,29 +73,37 @@ desc 'Start ubuntu docker container for testing and debugging.'
 task docker_dev: [:docker_down] do
   cmd = "docker compose run --service-ports \
   --name ruby_sw_apm_ubuntu_development ruby_sw_apm_ubuntu_development"
-  Dir.chdir('test') do
-    sh cmd do |ok, res|
-      puts "ok: #{ok}, #{res.inspect}"
-    end
-  end
+  docker_cmd_execute(cmd)
 end
 
-desc 'Start ubuntu docker container for testing and debugging.'
+desc 'Continue the docker container created last time'
+task :docker_con do
+  cmd = "docker container start ruby_sw_apm_ubuntu_development &&
+          docker exec -it ruby_sw_apm_ubuntu_development /bin/bash"
+  docker_cmd_execute(cmd)
+end
+
+desc 'Build the ubuntu docker container without cache'
 task :docker_build do
   cmd = 'docker compose build --no-cache'
-  Dir.chdir('test') do
-    sh cmd do |ok, res|
-      puts "ok: #{ok}, #{res.inspect}"
-    end
-  end
+  docker_cmd_execute(cmd)
 end
 
 desc 'Stop all containers that were started for testing and debugging'
 task :docker_down do
+  cmd = 'docker compose down -v --remove-orphans'
+  docker_cmd_execute(cmd)
+end
+
+def docker_cmd_execute(cmd)
   Dir.chdir('test') do
-    sh 'docker compose down -v --remove-orphans'
+    sh cmd do |ok, res|
+      puts "ok: #{ok}, #{res.inspect}"
+    end
   end
 end
+
+################ Build Gem Task ################
 
 desc 'alias for fetch_oboe_file_from_staging'
 task :fetch do

--- a/ext/oboe_metal/README.md
+++ b/ext/oboe_metal/README.md
@@ -86,7 +86,7 @@ export OBOE_DEV=true    # optional: if you want to install the nightly build lib
 
 gem install solarwinds_apm
 ```
-
+Reproduce the crash using this version of solarwinds_apm which provides extended debug information in the coredump.
 #### 2. Check the core dump size is not constrained
 
 ```console

--- a/ext/oboe_metal/README.md
+++ b/ext/oboe_metal/README.md
@@ -66,7 +66,11 @@ Some inspiring examples here:
 
 <https://medium.com/@zanker/finding-a-ruby-bug-with-gdb-56d6b321bc86>
 
-## Debug the c-code with core dump
+<!-- markdownlint-disable MD025 -->
+
+# Debug the c-code with core dump
+
+<!-- markdownlint-enable MD025 -->
 
 If the core dump is produced, it's easier to check the backtrace with it in gdb
 
@@ -76,9 +80,9 @@ For example, `(core dumped)` indicate the crash file is dumped
 ./start.sh: line 37:    65 Segmentation fault      (core dumped) ...
 ```
 
-### Prepare
+## Prepare
 
-#### 1. Install solarwinds_apm with debug symbol on
+### 1. Install solarwinds_apm with debug symbol on
 
 ```console
 export OBOE_DEBUG=true  # enable debug flag when compiling; and also download *.debug into lib/ when create the gem for ease of use
@@ -89,19 +93,19 @@ gem install solarwinds_apm
 
 Reproduce the crash using this version of solarwinds_apm which provides extended debug information in the coredump.
 
-#### 2. Check the core dump size is not constrained
+### 2. Check the core dump size is not constrained
 
 ```console
 ulimit -c unlimited       # have to set this for unlimited core dump file size without trimmed error message
 ```
 
-#### 3. Check if the crash report program is configured correctly
+### 3. Check if the crash report program is configured correctly
 
 Ubuntu use [apport](https://wiki.ubuntu.com/Apport); Debian use [kdump](https://mudongliang.github.io/2018/07/02/debian-enable-kernel-dump.html)
 
 In ubuntu, if apport is disabled via `service apport stop`, the core dump file will be stored in the current directory and named `core`. If apport is enabled, find the crash file (typically under `/var/crash`) and extract the CoreDump file from it using `apport-unpack <filename>.crash <destination>`.
 
-#### 4. Gather the `*.debug` file for oboe symbol
+### 4. Gather the `*.debug` file for oboe symbol
 
 Assume the gem has following file structure
 
@@ -135,16 +139,18 @@ The `*.debug` file need to be stored in ext/oboe_metal/lib/folder, then start th
 
 The `*.debug` file has to match the exact build of liboboe (e.g. version, system, etc.) to avoid CRC mismatch
 
-### Debug by checking the backtrace after obtain core dump file
+## Debug by checking the backtrace after obtain core dump file
 
-#### 1. Check that ruby is debuggable
+### 1. Check that ruby is debuggable
+
+Ensure that `ruby.h` is present by verifying the existence of the Ruby development library (e.g., `ruby-dev`).
 
 ```console
 type ruby           # => ruby is hashed (/root/.rbenv/shims/ruby)
 rbenv which ruby    # => /root/.rbenv/versions/3.1.0/bin/ruby
 ```
 
-#### 2. Load the core dump file in gdb
+### 2. Load the core dump file in gdb
 
 ```console
 gdb /root/.rbenv/versions/3.1.0/bin/ruby core

--- a/ext/oboe_metal/README.md
+++ b/ext/oboe_metal/README.md
@@ -82,7 +82,19 @@ For example, `(core dumped)` indicate the crash file is dumped
 
 ## Prepare
 
-### 1. Install solarwinds_apm with debug symbol on
+### 1. Check the core dump size is not constrained
+
+```console
+ulimit -c unlimited       # have to set this for unlimited core dump file size without trimmed error message
+```
+
+### 2. Check if the crash report program is configured correctly
+
+Ubuntu use [apport](https://wiki.ubuntu.com/Apport); Debian use [kdump](https://mudongliang.github.io/2018/07/02/debian-enable-kernel-dump.html)
+
+In ubuntu, if apport is disabled via `service apport stop`, the core dump file will be stored in the current directory and named `core`. If apport is enabled, find the crash file (typically under `/var/crash`) and extract the CoreDump file from it using `apport-unpack <filename>.crash <destination>`.
+
+### 3. Install solarwinds_apm with debug symbol on
 
 ```console
 export OBOE_DEBUG=true  # enable debug flag when compiling; and also download *.debug into lib/ when create the gem for ease of use
@@ -92,18 +104,6 @@ gem install solarwinds_apm
 ```
 
 Reproduce the crash using this version of solarwinds_apm which provides extended debug information in the coredump.
-
-### 2. Check the core dump size is not constrained
-
-```console
-ulimit -c unlimited       # have to set this for unlimited core dump file size without trimmed error message
-```
-
-### 3. Check if the crash report program is configured correctly
-
-Ubuntu use [apport](https://wiki.ubuntu.com/Apport); Debian use [kdump](https://mudongliang.github.io/2018/07/02/debian-enable-kernel-dump.html)
-
-In ubuntu, if apport is disabled via `service apport stop`, the core dump file will be stored in the current directory and named `core`. If apport is enabled, find the crash file (typically under `/var/crash`) and extract the CoreDump file from it using `apport-unpack <filename>.crash <destination>`.
 
 ### 4. Gather the `*.debug` file for oboe symbol
 

--- a/ext/oboe_metal/README.md
+++ b/ext/oboe_metal/README.md
@@ -17,10 +17,10 @@ rbenv which ruby    # => /home/wsh/.rbenv/versions/2.6.3/bin/ruby
 
 ## add debug info when compiling solarwinds_apm
 
-add this line to extconf.rb to turn off optimization
+enable `OBOE_DEBUG` to `true` to turn off optimization and enable debug information
 
-```ruby
-CONFIG["optflags"] = "-O0"
+```sh
+export OBOE_DEBUG=true
 ```
 
 ## start ruby app with gdb
@@ -86,7 +86,9 @@ export OBOE_DEV=true    # optional: if you want to install the nightly build lib
 
 gem install solarwinds_apm
 ```
+
 Reproduce the crash using this version of solarwinds_apm which provides extended debug information in the coredump.
+
 #### 2. Check the core dump size is not constrained
 
 ```console

--- a/ext/oboe_metal/README.md
+++ b/ext/oboe_metal/README.md
@@ -94,50 +94,18 @@ Ubuntu use [apport](https://wiki.ubuntu.com/Apport); Debian use [kdump](https://
 
 In ubuntu, if apport is disabled via `service apport stop`, the core dump file will be stored in the current directory and named `core`. If apport is enabled, find the crash file (typically under `/var/crash`) and extract the CoreDump file from it using `apport-unpack <filename>.crash <destination>`.
 
-### 3. Install solarwinds_apm with debug symbol on
+### 3. Install solarwinds_apm with comprehensive debug information
+
+Set the environment variable `OBOE_DEBUG` to `true` that download the special version of liboboe.
+
+This liboboe is compiled with RelWithDebInfo flag on, which include the debug symbol and other debug information.
 
 ```console
-export OBOE_DEBUG=true  # enable debug flag when compiling; and also download *.debug into lib/ when create the gem for ease of use
-export OBOE_DEV=true    # optional: if you want to install the nightly build liboboe
-
+export OBOE_DEBUG=true
 gem install solarwinds_apm
 ```
 
 Reproduce the crash using this version of solarwinds_apm which provides extended debug information in the coredump.
-
-### 4. Gather the `*.debug` file for oboe symbol
-
-Assume the gem has following file structure
-
-```console
-root@docker:~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/solarwinds_apm-6.0.6# tree .
-|-- ext
-|   `-- oboe_metal
-|       |-- init_solarwinds_apm.o
-|       |-- lib
-|       |   |-- liboboe-1.0-aarch64.so
-|       |   |-- liboboe-1.0.so.0 -> liboboe-1.0-aarch64.so
-|       |   `-- liboboe.so -> liboboe-1.0-aarch64.so
-|       |-- libsolarwinds_apm.so
-|       |-- oboe_api.o
-|       |-- oboe_swig_wrap.o
-|       `-- src
-|           |-- ...
-`-- lib
-    |-- libsolarwinds_apm.so
-    |-- oboe_metal.rb
-    |-- rails
-    |   ...
-    |-- solarwinds_apm
-    |   ...
-    `-- solarwinds_apm.rb
-
-18 directories, 79 files
-```
-
-The `*.debug` file need to be stored in ext/oboe_metal/lib/folder, then start the gdb
-
-The `*.debug` file has to match the exact build of liboboe (e.g. version, system, etc.) to avoid CRC mismatch
 
 ## Debug by checking the backtrace after obtain core dump file
 

--- a/ext/oboe_metal/README.md
+++ b/ext/oboe_metal/README.md
@@ -65,3 +65,50 @@ Some inspiring examples here:
 <https://jvns.ca/blog/2016/06/12/a-weird-system-call-process-vm-readv/>
 
 <https://medium.com/@zanker/finding-a-ruby-bug-with-gdb-56d6b321bc86>
+
+
+# Debug the c-code with core dump
+
+If the core dump is produced, it's easier to check the backtrace with it in gdb
+
+For example, `(core dumped)` indicate the crash file is dumped
+
+```console
+./start.sh: line 37:    65 Segmentation fault      (core dumped) ...
+```
+
+## Prepare
+
+1. Install solarwinds_apm with debug symbol on
+
+```console
+export OBOE_DEBUG=true          # for debug flag when compiling
+export OBOE_DEV=true            # optional: if you want to install the nightly build liboboe
+
+gem install solarwinds_apm
+```
+
+2. Check the core dump size is not constrained
+```console
+ulimit -c unlimited       # have to set this for unlimited core dump file size without trimmed error message
+```
+
+3. Check if the crash report program is configured correctly
+
+Ubuntu use [apport](https://wiki.ubuntu.com/Apport); Debian use [kdump](https://www.cyberciti.biz/faq/how-to-on-enable-kernel-crash-dump-on-debian-linux/)
+
+In ubuntu, if disable the apport by `service apport stop`, the core dump file will be stored in the current directory and named as `core`
+
+## Debug by checking the backtrace after obtain core dump file
+
+1. Check that ruby is debuggable
+```console
+type ruby           # => ruby is hashed (/root/.rbenv/shims/ruby)
+rbenv which ruby    # => /root/.rbenv/versions/3.1.0/bin/ruby
+```
+
+2. Load the core dump file in gdb
+```console
+gdb /root/.rbenv/versions/3.1.0/bin/ruby core
+(gdb) bt full      # backtrace full trace; investigate the issue from here
+```

--- a/ext/oboe_metal/extconf.rb
+++ b/ext/oboe_metal/extconf.rb
@@ -26,8 +26,8 @@ version     = File.read(File.join(ext_dir, 'src', 'VERSION')).strip
 
 # OBOE_DEBUG has the highest priorities over oboe environment
 if oboe_debug
-  swo_path = "https://agent-binaries.global.st-ssp.solarwinds.com/apm/c-lib/#{version}/relwithdebinfo"
-  puts 'Fetching c-lib from STAGING DEBUG Build'
+  swo_path = File.join('https://agent-binaries.cloud.solarwinds.com/apm/c-lib/', version, 'relwithdebinfo')
+  puts 'Fetching c-lib from PRODUCTION DEBUG Build'
 elsif ENV['OBOE_DEV'].to_s.casecmp('true').zero?
   swo_path = 'https://solarwinds-apm-staging.s3.us-west-2.amazonaws.com/apm/c-lib/nightly'
   puts 'Fetching c-lib from DEVELOPMENT Build'

--- a/ext/oboe_metal/extconf.rb
+++ b/ext/oboe_metal/extconf.rb
@@ -85,6 +85,7 @@ while retries.positive?
       success = true
       retries = 0
     else
+      puts "Checksum Verification Fail" # this is mainly for testing
       warn '== ERROR ================================================================='
       warn 'Checksum Verification failed for the c-extension of the solarwinds_apm gem'
       warn 'Installation cannot continue'
@@ -92,7 +93,7 @@ while retries.positive?
       warn "Checksum calculated from lib: #{clib_checksum}"
       warn 'Contact technicalsupport@solarwinds.com if the problem persists'
       warn '=========================================================================='
-      exit 1
+      retries = 0
     end
   rescue StandardError => e
     File.write(clib, '')

--- a/ext/oboe_metal/extconf.rb
+++ b/ext/oboe_metal/extconf.rb
@@ -83,9 +83,8 @@ while retries.positive?
     # with the `--verbose` flag
     if clib_checksum == checksum
       success = true
-      retries = 0
     else
-      puts "Checksum Verification Fail" # this is mainly for testing
+      puts 'Checksum Verification Fail' # this is mainly for testing
       warn '== ERROR ================================================================='
       warn 'Checksum Verification failed for the c-extension of the solarwinds_apm gem'
       warn 'Installation cannot continue'
@@ -93,8 +92,8 @@ while retries.positive?
       warn "Checksum calculated from lib: #{clib_checksum}"
       warn 'Contact technicalsupport@solarwinds.com if the problem persists'
       warn '=========================================================================='
-      retries = 0
     end
+    retries = 0
   rescue StandardError => e
     File.write(clib, '')
     retries -= 1

--- a/ext/oboe_metal/extconf.rb
+++ b/ext/oboe_metal/extconf.rb
@@ -139,7 +139,6 @@ if success
     $LDFLAGS << " #{ENV.fetch('LDFLAGS', nil)} '-Wl,-rpath=$$ORIGIN/../ext/oboe_metal/lib' -lrt"
     $CXXFLAGS += ' -std=c++11 '
 
-    # ____ include debug info, comment out when not debugging
     # OBOE_DEBUG need to be enabled before downloading and installing the gem
     if ENV['OBOE_DEBUG'].to_s.casecmp('true').zero?
       CONFIG['debugflags'] = '-ggdb3 '

--- a/solarwinds_apm.gemspec
+++ b/solarwinds_apm.gemspec
@@ -33,13 +33,8 @@ Gem::Specification.new do |s|
               'ext/oboe_metal/src/bson/bson.h',
               'ext/oboe_metal/src/bson/platform_hacks.h',
               'ext/oboe_metal/src/init_solarwinds_apm.cc',
-              'ext/oboe_metal/src/VERSION',
-              'ext/oboe_metal/lib/liboboe-1.0-alpine-x86_64.so.sha256',
-              'ext/oboe_metal/lib/liboboe-1.0-x86_64.so.sha256',
-              'ext/oboe_metal/lib/liboboe-1.0-aarch64.so.sha256',
-              'ext/oboe_metal/lib/liboboe-1.0-alpine-aarch64.so.sha256',
-              'ext/oboe_metal/lib/liboboe-1.0-lambda-x86_64.so.sha256',
-              'ext/oboe_metal/lib/liboboe-1.0-lambda-aarch64.so.sha256']
+              'ext/oboe_metal/src/VERSION']
+  s.files += Dir['ext/oboe_metal/lib/*']
 
   s.files -= ['Rakefile']
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -77,7 +77,7 @@ RUN curl -SL https://github.com/swig/swig/archive/refs/tags/v4.0.2.tar.gz \
 
 # set up github package credentials for pushing
 RUN mkdir ~/.gem \
-    && echo -e "---\n:github: Bearer ${BUNDLE_RUBYGEMS__PKG__GITHUB__COM}" >> ~/.gem/credentials \
+    && echo "---\n:github: Bearer ${BUNDLE_RUBYGEMS__PKG__GITHUB__COM}" >> ~/.gem/credentials \
     && chmod 0600 ~/.gem/credentials
 
 ENV PATH="/usr/local/bin:/root/.rbenv/bin:/root/.rbenv/shims:$PATH"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,8 +1,6 @@
 # Copyright (c) 2023 SolarWinds, LLC.
 # All rights reserved.
 
-version: "2.1"
-
 #########################################################################################################
 #
 # docker-compose to set up the development container

--- a/test/ext/extconf_test.rb
+++ b/test/ext/extconf_test.rb
@@ -19,14 +19,14 @@ describe 'extconf test' do
   it 'simple_extconf_test_with_OBOE_DEBUG' do
     ENV['OBOE_DEBUG'] = 'true'
     output = stub_for_mkmf_test
-    assert_includes output, 'Fetching c-lib from STAGING DEBUG Build'
+    assert_includes output, 'Fetching c-lib from PRODUCTION DEBUG Build'
   end
 
   it 'OBOE_DEBUG_surpass_other_env' do
     ENV['OBOE_DEBUG'] = 'true'
     ENV['OBOE_STAGING'] = 'true'
     output = stub_for_mkmf_test
-    assert_includes output, 'Fetching c-lib from STAGING DEBUG Build'
+    assert_includes output, 'Fetching c-lib from PRODUCTION DEBUG Build'
   end
 
   it 'simple_extconf_test_with_OBOE_STAGING' do

--- a/test/ext/extconf_test.rb
+++ b/test/ext/extconf_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2024 SolarWinds, LLC.
+# All rights reserved.
+
+require 'mkmf'
+require 'minitest_helper'
+require 'minitest/mock'
+require 'uri'
+require 'open-uri'
+
+describe 'extconf test' do
+  after do
+    ENV.delete('OBOE_DEBUG')
+    ENV.delete('OBOE_STAGING')
+    ENV.delete('OBOE_DEV')
+  end
+
+  it 'simple_extconf_test_with_OBOE_DEBUG' do
+    ENV['OBOE_DEBUG'] = 'true'
+    output = stub_for_mkmf_test
+    assert_includes output, 'Fetching c-lib from STAGING DEBUG Build'
+  end
+
+  it 'OBOE_DEBUG_surpass_other_env' do
+    ENV['OBOE_DEBUG'] = 'true'
+    ENV['OBOE_STAGING'] = 'true'
+    output = stub_for_mkmf_test
+    assert_includes output, 'Fetching c-lib from STAGING DEBUG Build'
+  end
+
+  it 'simple_extconf_test_with_OBOE_STAGING' do
+    ENV['OBOE_STAGING'] = 'true'
+    output = stub_for_mkmf_test
+    assert_includes output, 'Fetching c-lib from STAGING Build'
+  end
+
+  it 'simple_extconf_test_with_OBOE_DEV' do
+    ENV['OBOE_DEV'] = 'true'
+    output = stub_for_mkmf_test
+    assert_includes output, 'Fetching c-lib from DEVELOPMENT Build'
+  end
+
+  it 'simple_extconf_test_with_no_env_variable' do
+    ENV.delete('OBOE_STAGING')
+    output = stub_for_mkmf_test
+    assert_includes output, 'Fetching c-lib from PRODUCTION Build'
+    assert_includes output, 'Checksum Verification Fail'
+  end
+end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -362,16 +362,16 @@ end
 
 # For mkmf test case
 def capture_stdout_with_pipe
-  original_stderr = $stdout
+  original_stdout = $stdout
   read_io, write_io = IO.pipe
 
   # Redirect stderr to write_io (the writing end of the pipe)
   $stdout = write_io
   begin
-    yield  # Run the code block that generates stderr output
+    yield # Run the code block that generates stderr output
   ensure
-    $stdout = original_stderr  # Restore the original stderr
-    write_io.close  # Close the writing end of the pipe to stop sending data
+    $stdout = original_stdout # Restore the original stderr
+    write_io.close # Close the writing end of the pipe to stop sending data
   end
 
   captured_output = read_io.read

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -384,9 +384,9 @@ def stub_for_mkmf_test
     URI.stub(:parse, URI.parse('https://github.com')) do
       URI::HTTPS.stub(:open, nil) do
         File.stub(:symlink, nil) do
-          File.stub(:read, 'fake_read') do
-            MakeMakefile.stub(:have_library, true) do
-              MakeMakefile.stub(:create_makefile, true) do
+          MakeMakefile.stub(:have_library, true) do
+            MakeMakefile.stub(:create_makefile, true) do
+              File.stub(:read, '1.2.3') do
                 capture_stdout_with_pipe do
                   load 'ext/oboe_metal/extconf.rb'
                 end

--- a/test/test_setup.sh
+++ b/test/test_setup.sh
@@ -14,7 +14,7 @@ if [ -r /etc/alpine-release ]; then
     echo "Tests do not work on aarch64 alpine, skipping."
     exit
   else
-    apk update && apk add --upgrade git ruby-dev g++ make curl bash perl zlib-dev linux-headers shared-mime-info sqlite-dev grpc
+    apk update && apk add --upgrade git ruby-dev g++ make curl bash perl zlib-dev linux-headers shared-mime-info sqlite-dev yaml-dev grpc
   fi
 elif [ -r /etc/debian_version ]; then
   # this is for ubuntu (> 22.04) and debian


### PR DESCRIPTION
### Description

1. remove debug flag to reduce the size of apm
2. add instruction for debugging with core dump file
3. add extconf_test.rb to test the workflow of extconf (makefile construction) if `OBOE_DEBUG`, `OBOE_DEV`, `OBOE_STAGING` appears. The test case require deep stub on each different function to avoid c lib dependency.
4. `OBOE_DEBUG` will make the fetch of production release with relwithdebug directly.

### Test (if applicable)
