### PR TITLE
NH-90728 show whether publishing to staging or production

### DIFF
--- a/.github/workflows/build_publish_lambda_layer.yml
+++ b/.github/workflows/build_publish_lambda_layer.yml
@@ -96,12 +96,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - if: ${{ inputs.publish-dest == 'staging' }}
+        name: use staging credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.LAMBDA_PUBLISHER_ARN_STAGING }}
           aws-region: ${{ matrix.aws_region }}
 
       - if: ${{ inputs.publish-dest == 'production' }}
+        name: use production credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.LAMBDA_PUBLISHER_ARN_PROD }}


### PR DESCRIPTION
### Description
I didn't find anywhere to see this info in the previous workflow runs so added.

### Test (if applicable)
Workflow [run](https://github.com/solarwinds/apm-ruby/actions/runs/10821495745/job/30023680789) with this change.
