### PR TITLE
NH-94970: pg trace context injection

### DIFF
--- a/lib/solarwinds_apm/patch/tag_sql/sw_pg_patch.rb
+++ b/lib/solarwinds_apm/patch/tag_sql/sw_pg_patch.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative 'annotate_traceparent'
+
+module SolarWindsAPM
+  module Patch
+    module TagSql
+      module SWOPgPatch
+        EXEC_ISH_METHODS = %i[
+          exec
+          query
+          sync_exec
+          async_exec
+          exec_params
+          async_exec_params
+          sync_exec_params
+        ].freeze
+
+        EXEC_ISH_METHODS.each do |method|
+          define_method method do |*args, &block|
+            traceparent = AnnotateTraceparent.generate_traceparent
+            annotated_sql = ''
+            sql = args[0]
+
+            if traceparent.empty?
+              annotated_sql = sql
+            else
+              annotated_traceparent = "traceparent='#{AnnotateTraceparent.generate_traceparent}'"
+
+              current_span = ::OpenTelemetry::Trace.current_span
+              attributes_dup = current_span.attributes.dup
+              attributes_dup['sw.query_tag'] = "/*#{annotated_traceparent}*/"
+              current_span.instance_variable_set(:@attributes, attributes_dup.freeze)
+
+              annotated_sql = "#{sql} /*#{annotated_traceparent}*/"
+            end
+
+            args[0] = annotated_sql
+            super(*args, &block)
+          end
+        end
+      end
+    end
+  end
+end
+
+# need to prepend before pg instrumentation
+PG::Connection.prepend(SolarWindsAPM::Patch::TagSql::SWOPgPatch) if defined?(PG::Connection)

--- a/lib/solarwinds_apm/patch/tag_sql_patch.rb
+++ b/lib/solarwinds_apm/patch/tag_sql_patch.rb
@@ -5,3 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require_relative 'tag_sql/sw_mysql2_patch'
+require_relative 'tag_sql/sw_pg_patch'


### PR DESCRIPTION
### Description

### Test (if applicable)

[Prod](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/ED7AE42CCDAE82504065684562F7B2A2/28A287FF98C897D2/details/query/28A287FF98C897D2/queries?duration=3600&perspective=queries&queryId=4954a0b72c0c0a01&dboContext=samples&search=displayName%3A%22postgresql%20on%20ip-172-20-95-76.ec2.internal%20listening%20on%2034.238.40.181%3A5432%22&sort_by_queries=totalTime&sort_order_queries=descending)