### PR TITLE
NH-128063: cleanup Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -91,8 +91,7 @@ task :rubocop do
   _arg1, arg2 = ARGV
 
   rubocop_file = "#{__dir__}/rubocop_result.txt"
-  new_file = File.new(rubocop_file, 'w')
-  new_file.close
+  File.write(rubocop_file, '')
 
   `bundle exec rubocop --auto-correct` if arg2 == 'auto-safe'
   `bundle exec rubocop --auto-correct-all` if arg2 == 'auto-all'

--- a/Rakefile
+++ b/Rakefile
@@ -7,37 +7,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-require 'rubygems'
-require 'fileutils'
-require 'net/http'
-require 'optparse'
-require 'digest'
-require 'open-uri'
-require 'bundler/setup'
 require 'bundler/gem_tasks'
-require 'rake/testtask'
-
-Rake::TestTask.new do |t|
-  t.verbose = false
-  t.warning = false
-  t.ruby_opts = []
-  t.libs << 'test'
-
-  gem_file = ENV['BUNDLE_GEMFILE']&.split('/')&.last
-
-  case gem_file
-  when 'unit.gemfile'
-    t.test_files = FileList['test/api/*_test.rb'] +
-                   FileList['test/solarwinds_apm/*_test.rb'] +
-                   FileList['test/opentelemetry/*_test.rb'] +
-                   FileList['test/noop/*_test.rb'] +
-                   FileList['test/support/*_test.rb'] +
-                   FileList['test/sampling/*_test.rb'] -
-                   FileList['test/opentelemetry/otlp_processor_*_test.rb']
-  end
-end
-
-################ Docker Task ################
 
 desc "Run an official docker ruby image with the specified tag. The test suite is launched if
 runtests is set to true, else a shell session is started for interactive test runs. The platform
@@ -121,7 +91,6 @@ task :rubocop do
   _arg1, arg2 = ARGV
 
   rubocop_file = "#{__dir__}/rubocop_result.txt"
-  FileUtils.rm_f(rubocop_file)
   new_file = File.new(rubocop_file, 'w')
   new_file.close
 


### PR DESCRIPTION
### Description
Removed unused gem from Rakefile.
* remove Rake::TestTask as we don't use rake test to do unit test
* remove fileutils as it's not required to delete rubocop_result.txt before each run 
* remove bundler/setup as we don't need to load any additional gem in this Rakefile, so no need for it

```
rake build                                         # Build solarwinds_apm-7.1.1.gem into the pkg directory
rake build:checksum                                # Generate SHA512 checksum of solarwinds_apm-7.1.1.gem into the checksums directory
rake clean                                         # Remove any temporary products
rake clobber                                       # Remove any generated files
rake docker_build                                  # Build the ubuntu docker container without cache
rake docker_con                                    # Continue the docker container created last time
rake docker_dev                                    # Start ubuntu docker container for testing and debugging
rake docker_down                                   # Stop all containers that were started for testing and debugging
rake docker_tests[tag,runtests,platform,env_vars]  # Run an official docker ruby image with the specified tag
rake install                                       # Build and install solarwinds_apm-7.1.1.gem into system gems
rake install:local                                 # Build and install solarwinds_apm-7.1.1.gem into system gems without network access
rake release[remote]                               # Create tag v7.1.1 and build and push solarwinds_apm-7.1.1.gem to rubygems.org
rake rubocop                                       # Run rubocop and generate result
```
### Test (if applicable)

Tested docker-related task and rubocop.
